### PR TITLE
fix float comparison unit test fail

### DIFF
--- a/logger/transforms/test_true_winds_transform.py
+++ b/logger/transforms/test_true_winds_transform.py
@@ -207,7 +207,9 @@ class TestTrueWindsTransform(unittest.TestCase):
         self.assertEqual(result.data_id, 'truw')
         self.assertEqual(result.message_type, None)
         self.assertEqual(result.timestamp, expected['timestamp'])
-        self.assertDictEqual(result.fields, expected['fields'])
+        self.assertAlmostEqual(result.fields['ApparentWindDir'], expected['fields']['ApparentWindDir'], delta=0.00001)
+        self.assertAlmostEqual(result.fields['TrueWindDir'], expected['fields']['TrueWindDir'], delta=0.00001)
+        self.assertAlmostEqual(result.fields['TrueWindSpeed'], expected['fields']['TrueWindSpeed'], delta=0.00001)
         self.assertDictEqual(result.metadata, expected['metadata'])
       else:
         self.assertIsNone(result)


### PR DESCRIPTION
Apparently, assertDictEqual uses assertEqual for each member in the dict.  This doesn't work for floating point values so explicitly compare each field using assertAlmostEqual instead.

For reference, here's the test fail:

======================================================================
FAIL: test_default (logger.transforms.test_true_winds_transform.TestTrueWindsTransform)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/apo/development/openrvdas/logger/transforms/test_true_winds_transform.py", line 210, in test_default
    self.assertDictEqual(result.fields, expected['fields'])
AssertionError: {'TrueWindDir': 356.03324971116865, 'TrueWi[50 chars]8.02} != {'ApparentWindDir': 318.02, 'TrueWindDir': [50 chars]1929}
  {'ApparentWindDir': 318.02,
   'TrueWindDir': 356.03324971116865,
-  'TrueWindSpeed': 9.765859956501927}
?                                   ^

+  'TrueWindSpeed': 9.765859956501929}
?     