### PR TITLE
adding ability to define custom LF character

### DIFF
--- a/logger/readers/serial_reader.py
+++ b/logger/readers/serial_reader.py
@@ -26,7 +26,7 @@ class SerialReader(Reader):
   def __init__(self,  port, baudrate=9600, bytesize=8, parity='N',
                stopbits=1, timeout=None, xonxoff=False, rtscts=False,
                write_timeout=None, dsrdtr=False, inter_byte_timeout=None,
-               exclusive=None, max_bytes=None):
+               exclusive=None, max_bytes=None, lf=None):
     """
     If max_bytes is specified on initialization, read up to that many
     bytes when read() is called. If not specified, read() will read up to
@@ -47,11 +47,14 @@ class SerialReader(Reader):
                                 inter_byte_timeout=inter_byte_timeout,
                                 exclusive=exclusive)
     self.max_bytes = max_bytes
+    self.lf = lf
 
   ############################
   def read(self):
     try:
-      if self.max_bytes:
+      if self.lf:
+        record = self.serial.read_until(self.lf, self.max_bytes)
+      elif self.max_bytes:
         record = self.serial.read(self.max_bytes)
       else:
         record = self.serial.readline()


### PR DESCRIPTION
I don't have a way to fully test but this looks like it will work...  here's the link to the read_until function in the pySerial docs: https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.read_until