### PR TITLE
Introduction of a polled serial reader

### DIFF
--- a/logger/readers/polled_serial_reader.py
+++ b/logger/readers/polled_serial_reader.py
@@ -26,7 +26,7 @@ class PolledSerialReader(SerialReader):
                      parity=parity, stopbits=stopbits, timeout=timeout,
                      xonxoff=xonxoff, rtscts=rtscts, write_timeout=write_timeout,
                      dsrdtr=dsrdtr, inter_byte_timeout=inter_byte_timeout,
-                     exclusive=exclusive)
+                     exclusive=exclusive, max_bytes=None, lf=None)
 
     self.start_cmd = start_cmd
     self.pre_read_cmd = pre_read_cmd

--- a/logger/readers/polled_serial_reader.py
+++ b/logger/readers/polled_serial_reader.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+
+sys.path.append('.')
+
+from logger.readers.serial_reader import SerialReader
+
+################################################################################
+class PolledSerialReader(SerialReader):
+  """
+  Read text records from a serial port.
+  """
+  def __init__(self,  port, baudrate=9600, bytesize=8, parity='N',
+               stopbits=1, timeout=None, xonxoff=False, rtscts=False,
+               write_timeout=None, dsrdtr=False, inter_byte_timeout=None,
+               exclusive=None, max_bytes=None, lf=None, start_cmd=None,
+               pre_read_cmd=None, stop_cmd=None):
+    """
+    Extends the standard serial reader by allowing the user to define
+    strings to send to the serial host on startup, before each read and 
+    just prior to the reader being destroyed
+    """
+    super().__init__(port=port, baudrate=baudrate, bytesize=bytesize,
+                     parity=parity, stopbits=stopbits, timeout=timeout,
+                     xonxoff=xonxoff, rtscts=rtscts, write_timeout=write_timeout,
+                     dsrdtr=dsrdtr, inter_byte_timeout=inter_byte_timeout,
+                     exclusive=exclusive)
+
+    self.start_cmd = start_cmd
+    self.pre_read_cmd = pre_read_cmd
+    self.stop_cmd = stop_cmd
+
+    if(self.start_cmd):
+      try:
+        self.serial.write(self.start_cmd.encode('utf-8'))
+      except serial.serialutil.SerialException as e:
+        logging.error(str(e))
+
+  ############################
+  def read(self):
+    try:
+      if self.pre_read_cmd:
+        self.serial.write(self.pre_read_cmd.encode('utf-8'))
+
+      record = self.read()
+      return record
+    except serial.serialutil.SerialException as e:
+      logging.error(str(e))
+      return None
+
+  ############################
+  def __del__(self):
+    if(self.stop_cmd):
+      try:
+        self.serial.write(self.stop_cmd.encode('utf-8'))
+      except serial.serialutil.SerialException as e:
+        logging.error(str(e))

--- a/logger/readers/serial_reader.py
+++ b/logger/readers/serial_reader.py
@@ -26,7 +26,7 @@ class SerialReader(Reader):
   def __init__(self,  port, baudrate=9600, bytesize=8, parity='N',
                stopbits=1, timeout=None, xonxoff=False, rtscts=False,
                write_timeout=None, dsrdtr=False, inter_byte_timeout=None,
-               exclusive=None, max_bytes=None):
+               exclusive=None, max_bytes=None, lf=None):
     """
     If max_bytes is specified on initialization, read up to that many
     bytes when read() is called. If not specified, read() will read up to
@@ -47,11 +47,14 @@ class SerialReader(Reader):
                                 inter_byte_timeout=inter_byte_timeout,
                                 exclusive=exclusive)
     self.max_bytes = max_bytes
+    self.lf = lf
 
   ############################
   def read(self):
     try:
-      if self.max_bytes:
+      if self.lf:
+        record = self.serial.read_until(self.lf, self.max_bytes)
+      elif self.max_bytes:
         record = self.serial.read(self.max_bytes)
       else:
         record = self.serial.readline()


### PR DESCRIPTION
Polled serial reader extends the serial reader to include options for defining an initialzation string to be sent to the host at startup, a string to be sent to the host prior to reading new serial data (some sensors require a command to be sent to them prior to transmitting data back) and a string to send to the host when the reader is destroyed.

This is completely untested